### PR TITLE
[RUN-1672] skcpu: use baseline CPU for jit

### DIFF
--- a/src/core/SkCpu.cpp
+++ b/src/core/SkCpu.cpp
@@ -9,6 +9,7 @@
 #include "include/core/SkString.h"
 #include "include/private/SkOnce.h"
 #include "src/core/SkCpu.h"
+#include "src/core/SkRecordReplay.h"
 
 #if defined(SK_CPU_X86)
     #if defined(_MSC_VER)
@@ -157,5 +158,10 @@ uint32_t SkCpu::gCachedFeatures = 0;
 
 void SkCpu::CacheRuntimeFeatures() {
     static SkOnce once;
-    once([] { gCachedFeatures = read_cpu_features(); });
+    once([]{
+        if (SkRecordReplayIsReplaying()) {
+            return;
+        }
+        gCachedFeatures = read_cpu_features();
+    });
 }

--- a/src/core/SkRecordReplay.h
+++ b/src/core/SkRecordReplay.h
@@ -16,5 +16,7 @@ extern int SkRecordReplayPointerId(const void* ptr);
 extern bool SkRecordReplayAreEventsDisallowed();
 extern void SkRecordReplayBeginPassThroughEvents();
 extern void SkRecordReplayEndPassThroughEvents();
+extern bool SkRecordReplayIsRecordingOrReplaying();
+extern bool SkRecordReplayIsReplaying();
 
 #endif


### PR DESCRIPTION
We get crashes because we start using a new CPU at the start of a replay, and get migrated to a machine with an older CPU. Disable the cpuid checks so that we always use the most baseline CPU for the jit.

While we're here, use a thread-safe once.

Fixes https://linear.app/replay/issue/RUN-1672