### PR TITLE
remove overtly aggressive Assert until we know more

### DIFF
--- a/src/core/SkPixelRef.cpp
+++ b/src/core/SkPixelRef.cpp
@@ -73,9 +73,6 @@ uint32_t SkPixelRef::getGenerationID() const {
         // if we got here via the else path (pretty unlikely, but possible).
     }
 
-    if (!SkRecordReplayAreEventsDisallowed())
-        SkRecordReplayAssert("[RUN-593-1824] SkPixelRef::getGenerationID %u", id);
-
     return id & ~1u;  // Mask off bottom unique bit.
 }
 


### PR DESCRIPTION
* Partial rollback from previous asserts (see [here](https://linear.app/replay/issue/RUN-593/chromium-mismatch-skresourcecachefind#comment-739e094f))
* For some reason, this Assert is triggering *a lot* and just about anywhere. Need to find out more and whether this is expected or not.