### PR TITLE
RUN-2367: Order SkCachedData::fMutex

### DIFF
--- a/src/core/SkCachedData.cpp
+++ b/src/core/SkCachedData.cpp
@@ -12,25 +12,25 @@
 #include "src/core/SkRecordReplay.h"
 
 SkCachedData::SkCachedData(void* data, size_t size)
-    : fData(data)
+    : fMutex("SkCachedData")
+    , fData(data)
     , fSize(size)
     , fRefCnt(1)
     , fStorageType(kMalloc_StorageType)
     , fInCache(false)
     , fIsLocked(true)
-    , fMutex("SkCachedData")
 {
     fStorage.fMalloc = data;
 }
 
 SkCachedData::SkCachedData(size_t size, SkDiscardableMemory* dm)
-    : fData(dm->data())
+    : fMutex("SkCachedData")
+    , fData(dm->data())
     , fSize(size)
     , fRefCnt(1)
     , fStorageType(kDiscardableMemory_StorageType)
     , fInCache(false)
     , fIsLocked(true)
-    , fMutex("SkCachedData")
 {
     fStorage.fDM = dm;
 }

--- a/src/core/SkCachedData.cpp
+++ b/src/core/SkCachedData.cpp
@@ -12,7 +12,7 @@
 #include "src/core/SkRecordReplay.h"
 
 SkCachedData::SkCachedData(void* data, size_t size)
-    : fMutex("SkCachedData")
+    : fMutex("SkCachedData.fMutex")
     , fData(data)
     , fSize(size)
     , fRefCnt(1)
@@ -24,7 +24,7 @@ SkCachedData::SkCachedData(void* data, size_t size)
 }
 
 SkCachedData::SkCachedData(size_t size, SkDiscardableMemory* dm)
-    : fMutex("SkCachedData")
+    : fMutex("SkCachedData.fMutex")
     , fData(dm->data())
     , fSize(size)
     , fRefCnt(1)

--- a/src/core/SkCachedData.cpp
+++ b/src/core/SkCachedData.cpp
@@ -18,6 +18,7 @@ SkCachedData::SkCachedData(void* data, size_t size)
     , fStorageType(kMalloc_StorageType)
     , fInCache(false)
     , fIsLocked(true)
+    , fMutex("SkCachedData")
 {
     fStorage.fMalloc = data;
 }
@@ -29,6 +30,7 @@ SkCachedData::SkCachedData(size_t size, SkDiscardableMemory* dm)
     , fStorageType(kDiscardableMemory_StorageType)
     , fInCache(false)
     , fIsLocked(true)
+    , fMutex("SkCachedData")
 {
     fStorage.fDM = dm;
 }
@@ -76,7 +78,8 @@ void SkCachedData::internalUnref(bool fromCache) const {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 void SkCachedData::inMutexRef(bool fromCache) {
-    SkRecordReplayAssert("[RUN-593-1374] SkCachedData::inMutexRef %d %d %d", fRefCnt, fInCache, fromCache);
+    SkRecordReplayAssert(
+            "[RUN-2367-2368] SkCachedData::inMutexRef %d %d %d", fRefCnt, fInCache, fromCache);
     if ((1 == fRefCnt) && fInCache) {
         this->inMutexLock();
     }
@@ -90,7 +93,7 @@ void SkCachedData::inMutexRef(bool fromCache) {
 
 bool SkCachedData::inMutexUnref(bool fromCache) {
     SkRecordReplayAssert(
-            "[RUN-593-1783] SkCachedData::inMutexUnref %d %d %d", fRefCnt, fInCache, fromCache);
+            "[RUN-2367-2368] SkCachedData::inMutexUnref %d %d %d", fRefCnt, fInCache, fromCache);
     switch (--fRefCnt) {
         case 0:
             // we're going to be deleted, so we need to be unlocked (for DiscardableMemory)
@@ -125,7 +128,7 @@ void SkCachedData::inMutexLock() {
     SkASSERT(!fIsLocked);
     fIsLocked = true;
 
-    SkRecordReplayAssert("[RUN-593-1374] SkCachedData::inMutexLock %d", (int)fStorageType);
+    SkRecordReplayAssert("[RUN-2367-2368] SkCachedData::inMutexLock %d", (int)fStorageType);
 
     switch (fStorageType) {
         case kMalloc_StorageType:

--- a/src/core/SkMaskCache.cpp
+++ b/src/core/SkMaskCache.cpp
@@ -168,6 +168,10 @@ SkCachedData* SkMaskCache::FindAndRef(SkScalar sigma, SkBlurStyle style,
                                       SkResourceCache* localCache) {
     MaskValue result;
     RectsBlurKey key(sigma, style, rects, count);
+
+    SkRecordReplayAssert(
+            "[RUN-2367-2368] SkMaskCache::FindAndRef %d", !!localCache);
+
     if (!CHECK_LOCAL(localCache, find, Find, key, RectsBlurRec::Visitor, &result)) {
         return nullptr;
     }

--- a/src/core/SkResourceCache.cpp
+++ b/src/core/SkResourceCache.cpp
@@ -555,9 +555,6 @@ void SkResourceCache::CheckMessages() {
 bool SkResourceCache::Find(const Key& key, FindVisitor visitor, void* context) {
     SkAutoMutexExclusive am(resource_cache_mutex());
     bool rv = get_cache()->find(key, visitor, context);
-
-    // https://linear.app/replay/issue/RUN-593
-    SkRecordReplayAssert("[RUN-593] SkResourceCache::Find Done %d", rv);
     return rv;
 }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/829
* https://linear.app/replay/issue/RUN-2367#comment-b21b7772
* Test mostly pass, with the exception of those tests that are also not passing on tip of tree :heavy_check_mark: 