### PR TITLE
Assert SkTypefaceCache::findByProcAndRef

### DIFF
--- a/src/ports/SkFontMgr_win_dw.cpp
+++ b/src/ports/SkFontMgr_win_dw.cpp
@@ -427,6 +427,8 @@ struct ProtoDWriteTypeface {
 };
 
 static bool FindByDWriteFont(SkTypeface* cached, void* ctx) {
+    SkRecordReplayAssert("[RUN-2612-2639] FindByDWriteFont %u", cached->uniqueID());
+
     DWriteFontTypeface* cshFace = reinterpret_cast<DWriteFontTypeface*>(cached);
     ProtoDWriteTypeface* ctxFace = reinterpret_cast<ProtoDWriteTypeface*>(ctx);
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/910
* https://linear.app/replay/issue/RUN-2612/mismatch-in-skfontmgr-directwritemaketypefacefromdwritefont#comment-24af1d8d