### PR TITLE
RUN-2612: Order SkFontMgr_DirectWrite

### DIFF
--- a/src/ports/SkFontMgr_win_dw.cpp
+++ b/src/ports/SkFontMgr_win_dw.cpp
@@ -346,6 +346,7 @@ public:
         , fFontCollection(SkRefComPtr(fontCollection))
         , fLocaleName(localeNameLength)
         , fDefaultFamilyName(defaultFamilyNameLength)
+        , fTFCacheMutex("SkFontMgr_DirectWrite")
     {
         memcpy(fLocaleName.get(), localeName, localeNameLength * sizeof(WCHAR));
         memcpy(fDefaultFamilyName.get(), defaultFamilyName, defaultFamilyNameLength*sizeof(WCHAR));


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/933
* https://linear.app/replay/issue/RUN-2612/mismatch-in-skfontmgr-directwritemaketypefacefromdwritefont#comment-6ede4560