### PR TITLE
For replays that have diverged, don't try to create new fonts.

### DIFF
--- a/src/core/SkRecordReplay.cpp
+++ b/src/core/SkRecordReplay.cpp
@@ -40,6 +40,7 @@ static bool (*gRecordReplayAreEventsDisallowed)();
 static void (*gRecordReplayBeginPassThroughEvents)();
 static void (*gRecordReplayEndPassThroughEvents)();
 static bool (*gRecordReplayIsReplaying)(void);
+static bool (*gRecordReplayHasDivergedFromRecording)(void);
 static uintptr_t (*gRecordReplayValue)(const char* why, uintptr_t v);
 
 template <typename Src, typename Dst>
@@ -79,6 +80,7 @@ static inline bool EnsureInitialized() {
     RecordReplayLoadSymbol("RecordReplayBeginPassThroughEvents", gRecordReplayBeginPassThroughEvents);
     RecordReplayLoadSymbol("RecordReplayEndPassThroughEvents", gRecordReplayEndPassThroughEvents);
     RecordReplayLoadSymbol("RecordReplayIsReplaying", gRecordReplayIsReplaying);
+    RecordReplayLoadSymbol("RecordReplayHasDivergedFromRecording", gRecordReplayHasDivergedFromRecording);
     RecordReplayLoadSymbol("RecordReplayValue", gRecordReplayValue);
 
     gRecordingOrReplaying =
@@ -174,6 +176,12 @@ void SkRecordReplayEndPassThroughEvents() {
 
 bool SkRecordReplayIsReplaying(void) {
   return EnsureInitialized() && gRecordReplayIsReplaying();
+}
+
+bool SkRecordReplayHasDivergedFromRecording(void) {
+  return EnsureInitialized() && 
+    gRecordReplayIsReplaying() && 
+    gRecordReplayHasDivergedFromRecording();
 }
 
 uintptr_t SkRecordReplayValue(const char* why, uintptr_t v) {

--- a/src/core/SkRecordReplay.h
+++ b/src/core/SkRecordReplay.h
@@ -23,6 +23,7 @@ extern bool SkRecordReplayAreEventsDisallowed(const char* why = nullptr);
 extern void SkRecordReplayBeginPassThroughEvents();
 extern void SkRecordReplayEndPassThroughEvents();
 extern bool SkRecordReplayIsReplaying();
+extern bool SkRecordReplayHasDivergedFromRecording();
 extern uintptr_t SkRecordReplayValue(const char* why, uintptr_t v);
 
 #endif

--- a/src/ports/SkFontMgr_FontConfigInterface.cpp
+++ b/src/ports/SkFontMgr_FontConfigInterface.cpp
@@ -294,6 +294,14 @@ protected:
     {
         SkAutoMutexExclusive ama(fMutex);
 
+        // If we've run out of recording data, then following this chain of logic will lead to
+        // hangs, as we await conditional vars on epoll waiters that don't actually exist, held
+        // by threads that are dead (waiting forever.)  Luckily, it seems we can just early out 
+        // and have Chromium use some defaults for us.
+        if (SkRecordReplayHasDivergedFromRecording()) {
+            return nullptr;
+        }
+
         // Check if this request is already in the request cache.
         using Request = SkFontRequestCache::Request;
         std::unique_ptr<Request> request(Request::Create(requestedFamilyName, requestedStyle));


### PR DESCRIPTION
Part of the fix for [RUN-3341](https://linear.app/replay/issue/RUN-3341/fix-hang-threadwaitforeverforrecordedcall-epoll-wait).

During a call to `getComputedStyle`, we end up kicking off a layout of the page, which eventually does something involving font height computation, which for some reason requests a font that is not in the font cache.  This leads the font system to invoke a mojo call to get this font, which hangs indefinitely, because the thread on the other end of the call is looping forever, because it tried to `epoll_wait` without any more recording data.

Basically, I'm hoping we can just ignore/sidestep all this font stuff, and just return some null ptrs (which blink/skia do indeed handle), and have blink/skia use cached defaults.  This is the skia-related work, there's another chromium PR for a similar call.